### PR TITLE
CMS cover image preview

### DIFF
--- a/src/cms/preview-templates/ProjectPagePreview.tsx
+++ b/src/cms/preview-templates/ProjectPagePreview.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
-import { IntlProvider, addLocaleData } from 'react-intl';
 
 import { ProjectTemplate } from '../../templates/project';
-import { NavBar } from '../../components/NavBar';
-
-import * as enData from 'react-intl/locale-data/en';
-import en from '../../i18n/en';
-
-addLocaleData([...enData]);
+import { Layout } from '../../components/Layout';
 
 interface Props {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -23,20 +17,15 @@ const ProjectPagePreview = ({ entry, getAsset }: Props) => {
   const location = locationData && locationData.toJS();
 
   return (
-    <IntlProvider locale="en" messages={en}>
-      <div className="bg-gray-200 min-h-screen overflow-x-hidden">
-        <NavBar language="en" />
-        <main className="pb-4">
-          <ProjectTemplate
-            title={entry.getIn(['data', 'title'])}
-            cover={getAsset(entry.getIn(['data', 'cover']))}
-            html={entry.getIn(['data', 'body'])}
-            openingTimes={openingTimes}
-            location={location}
-          />
-        </main>
-      </div>
-    </IntlProvider>
+    <Layout language="en">
+      <ProjectTemplate
+        title={entry.getIn(['data', 'title'])}
+        cover={getAsset(entry.getIn(['data', 'cover']))}
+        html={entry.getIn(['data', 'body'])}
+        openingTimes={openingTimes}
+        location={location}
+      />
+    </Layout>
   );
 };
 

--- a/src/components/HeroTitle.tsx
+++ b/src/components/HeroTitle.tsx
@@ -3,20 +3,32 @@ import * as React from 'react';
 import { graphql } from 'gatsby';
 import Img, { FluidObject } from 'gatsby-image';
 
-interface Props {
-  media?: {
-    childImageSharp: {
-      fluid: FluidObject;
-    };
+export interface HeroMedia {
+  childImageSharp: {
+    fluid: FluidObject;
   };
+}
+
+interface Props {
+  media?: HeroMedia | string;
   title: string;
+}
+
+function isFluidMedia(media: HeroMedia | string): media is HeroMedia {
+  return (media as HeroMedia).childImageSharp !== undefined;
 }
 
 export const HeroTitle = ({ media, title }: Props) => (
   <section className="relative flex items-stretch flex-col content-between py-12 md:py-32">
     <div className="absolute inset-0">
-      {media && media.childImageSharp && (
+      {media && isFluidMedia(media) && (
         <Img className="w-full h-full" fluid={media.childImageSharp.fluid} />
+      )}
+      {media && !isFluidMedia(media) && (
+        <img
+          className="absolute top-0 left-0 object-cover object-center w-full h-full"
+          src={media}
+        />
       )}
     </div>
     <div className="absolute inset-0 bg-black opacity-50 w-full h-full" />

--- a/src/templates/project.tsx
+++ b/src/templates/project.tsx
@@ -1,19 +1,12 @@
 import * as React from 'react';
 
 import { graphql } from 'gatsby';
-import { FluidObject } from 'gatsby-image';
 
-import { HeroTitle } from '../components/HeroTitle';
+import { HeroTitle, HeroMedia } from '../components/HeroTitle';
 import { Layout } from '../components/Layout';
 import { LocationInfo } from '../components/LocationInfo';
 import { OpeningTimes } from '../components/OpeningTimes';
 import { LocaleType } from '../utils/types';
-
-interface CoverImage {
-  childImageSharp: {
-    fluid: FluidObject;
-  };
-}
 
 interface OpeningTime {
   day: string;
@@ -23,7 +16,7 @@ interface OpeningTime {
 
 interface TemplateProps {
   title: string;
-  cover: CoverImage;
+  cover: HeroMedia;
   openingTimes: OpeningTime[];
   location?: {
     description: string;
@@ -79,7 +72,7 @@ interface PageProps {
       };
       frontmatter: {
         title: string;
-        cover: CoverImage;
+        cover: HeroMedia;
         categories: string[];
         openingTimes: OpeningTime[];
         location?: {
@@ -97,15 +90,17 @@ const Project = (props: PageProps) => {
   const {
     data: { project }
   } = props;
+  const { html, frontmatter, fields } = project;
+  const { title, cover, openingTimes, location } = frontmatter;
 
   return (
-    <Layout language={project.fields.language}>
+    <Layout language={fields.language}>
       <ProjectTemplate
-        title={project.frontmatter.title}
-        cover={project.frontmatter.cover}
-        html={project.html}
-        openingTimes={project.frontmatter.openingTimes}
-        location={project.frontmatter.location}
+        title={title}
+        cover={cover}
+        html={html}
+        openingTimes={openingTimes}
+        location={location}
       />
     </Layout>
   );


### PR DESCRIPTION
Fixes issue #77.

When image comes from CMS it's a `string`, not an object containing `childImageSharp`, like `gatsby-image` expects. In this case fall back to a standard `<img>`. 