### PR TITLE
Fix CMS preview formatting of body content

### DIFF
--- a/src/cms/preview-templates/ProjectPagePreview.tsx
+++ b/src/cms/preview-templates/ProjectPagePreview.tsx
@@ -8,9 +8,11 @@ interface Props {
   entry: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getAsset: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  widgetFor: any;
 }
 
-const ProjectPagePreview = ({ entry, getAsset }: Props) => {
+const ProjectPagePreview = ({ entry, getAsset, widgetFor }: Props) => {
   const openingTimesData = entry.getIn(['data', 'openingTimes']);
   const openingTimes = openingTimesData ? openingTimesData.toJS() : [];
   const locationData = entry.getIn(['data', 'location']);
@@ -21,10 +23,11 @@ const ProjectPagePreview = ({ entry, getAsset }: Props) => {
       <ProjectTemplate
         title={entry.getIn(['data', 'title'])}
         cover={getAsset(entry.getIn(['data', 'cover']))}
-        html={entry.getIn(['data', 'body'])}
         openingTimes={openingTimes}
         location={location}
-      />
+      >
+        {widgetFor('body')}
+      </ProjectTemplate>
     </Layout>
   );
 };

--- a/src/templates/project.tsx
+++ b/src/templates/project.tsx
@@ -15,12 +15,13 @@ interface OpeningTime {
 
 interface TemplateProps {
   title: string;
-  cover: HeroMedia;
+  cover: HeroMedia | string;
   openingTimes: OpeningTime[];
   location?: {
     description: string;
   };
-  html: string;
+  html?: string;
+  children?: React.ReactNode;
 }
 
 export const ProjectTemplate = (props: TemplateProps) => {
@@ -35,11 +36,15 @@ export const ProjectTemplate = (props: TemplateProps) => {
       <div className="max-w-3xl mx-auto px-4 text-center">
         <article className="bg-white border p-4 mb-4">
           <h3 className="text-center">Information</h3>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: html
-            }}
-          />
+          {html ? (
+            <div
+              dangerouslySetInnerHTML={{
+                __html: html
+              }}
+            />
+          ) : (
+            props.children
+          )}
         </article>
         <aside className="md:flex flex-row flex-wrap justify-between">
           <div className="bg-white border p-4 mb-4 md:w-2/5 h-full md:mr-4 flex-grow">


### PR DESCRIPTION
## Related issue

Fixes #224 

## Description of changes

- Use the Markdown preview component when rendering the Project preview template.
- `ProjectTemplate` can now take a pre-formatted child component to render content as an alternative to an HTML string prop.
