### PR TITLE
Fix: don't wrap opening times on small devices

### DIFF
--- a/src/components/OpeningTimes.tsx
+++ b/src/components/OpeningTimes.tsx
@@ -24,12 +24,16 @@ export const OpeningTimes = ({ days }: Props) => (
           const prevDay = index > 0 ? days[index - 1].day : undefined;
           const isSameDay = day.day === prevDay;
           return (
-            <div key={day.day} className="flex justify-start">
-              <div className="flex-1">{isSameDay ? '' : day.day}</div>
-              <div className="flex-1">
-                <FormattedTime value={day.open} />
-                {' - '}
-                <FormattedTime value={day.close} />
+            <div key={day.day} className="flex sm:px-5">
+              <div className="flex flex-2 sm:flex-1">
+                {isSameDay ? '' : day.day}
+              </div>
+              <div className="flex flex-3 sm:flex-1">
+                <span>
+                  <FormattedTime value={new Date(day.open)} />
+                  <span>{' - '}</span>
+                  <FormattedTime value={new Date(day.close)} />
+                </span>
               </div>
             </div>
           );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,10 @@ module.exports = {
       screens: {
         lg: '960px',
         xl: '960px'
+      },
+      flex: {
+        '2': '2 2 0%',
+        '3': '3 3 0%'
       }
     }
   },


### PR DESCRIPTION
## Purpose

Fixes #241 

## Description of changes

Use `flex: 2` and `flex: 3` on small devices to give a bit more space to opening times and a bit less to day names.

Only tested with English, should be revisited when translations land.

## Screenshots (if relevant)

![image](https://user-images.githubusercontent.com/5207037/62661016-9db27880-b967-11e9-93ef-7f43878c3d2c.png)
